### PR TITLE
Update catalog.yaml

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -7,10 +7,6 @@ org_name: Sandbox
 metadata:
   name: sotoseven
   description: Demo test
-#  links:
-#    - url: https://dev.azure.com/TR-Harness/Harness-POV/_workitems/recentlycreated/
-#      title: Azure DevOps Boards
-#      icon: microsoft-azure  
   additionalInfo:
     tfc_current_state: ""
     tfc_policy_check: ""
@@ -38,3 +34,31 @@ relations:
       kind: user
       namespace: account
       name: alejandro.soto@harness.io
+#  links:
+#    - url: https://dev.azure.com/TR-Harness/Harness-POV/_workitems/recentlycreated/
+#      title: Azure DevOps Boards
+#      icon: microsoft-azure  
+#  links:
+#    - url: https://dev.azure.com/TR-Harness/Harness-POV/_workitems/recentlycreated/
+#      title: Azure DevOps Boards
+#      icon: microsoft-azure  
+#  links:
+#    - url: https://dev.azure.com/TR-Harness/Harness-POV/_workitems/recentlycreated/
+#      title: Azure DevOps Boards
+#      icon: microsoft-azure  
+#  links:
+#    - url: https://dev.azure.com/TR-Harness/Harness-POV/_workitems/recentlycreated/
+#      title: Azure DevOps Boards
+#      icon: microsoft-azure  
+#  links:
+#    - url: https://dev.azure.com/TR-Harness/Harness-POV/_workitems/recentlycreated/
+#      title: Azure DevOps Boards
+#      icon: microsoft-azure  
+#  links:
+#    - url: https://dev.azure.com/TR-Harness/Harness-POV/_workitems/recentlycreated/
+#      title: Azure DevOps Boards
+#      icon: microsoft-azure  
+#  links:
+#    - url: https://dev.azure.com/TR-Harness/Harness-POV/_workitems/recentlycreated/
+#      title: Azure DevOps Boards
+#      icon: microsoft-azure  


### PR DESCRIPTION
This pull request modifies the `catalog.yaml` file by removing commented-out Azure DevOps Board links from the `metadata` section and adding multiple commented-out Azure DevOps Board links under the `relations` section.

Changes to `catalog.yaml`:

* Removed a single commented-out Azure DevOps Board link from the `metadata` section, cleaning up unused configuration.
* Added multiple commented-out Azure DevOps Board links under the `relations` section, likely as placeholders or for future use.